### PR TITLE
revert: fix: replace repo URL with SSH for image updater (#72)

### DIFF
--- a/appsets/prod-appset.yaml
+++ b/appsets/prod-appset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       project: default
       source:
-        repoURL: git@github.com:hajle-silesia/container-orchestration-cd.git
+        repoURL: https://github.com/hajle-silesia/container-orchestration-cd.git
         targetRevision: master
         path: '{{.path.path}}'
       destination:


### PR DESCRIPTION
This reverts commit 63e07f9d7d0d173fe8ae6d5550dd8a44317ec66f.