### PR TITLE
fix: move to the latest External Secrets version supporting former API

### DIFF
--- a/apps/external-secrets/Chart.yaml
+++ b/apps/external-secrets/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: external-secrets
-    version: 0.19.0
+    version: 0.16.2
     repository: "https://charts.external-secrets.io"


### PR DESCRIPTION
version